### PR TITLE
Updated the doc regex.

### DIFF
--- a/library/ChatGPT.php
+++ b/library/ChatGPT.php
@@ -239,7 +239,7 @@ class ChatGPT {
         ];
 
         $matches = [];
-        preg_match_all( '/@param\s+(\S+)\s+\$(\S+)[^\S\r\n]?([^\r\n]+)?/', $doc_comment, $matches );
+        preg_match_all('/@param *(\w+) *\$(\w+) ?(.*?)$/gsm', $doc_comment, $matches);
 
         $types = $matches[1];
         $names = $matches[2];


### PR DESCRIPTION
Warning: I am not a PHP dev, I did not run the code, I only tested the regex on sites like [Regex101](https://regex101.com).

![image](https://github.com/unconv/php-gpt-funcs/assets/53124886/20221b85-dc42-4f93-9621-6df589c25e05)

This does not fix the existing bug of not matching the entire description if it is split on multiple lines.