### PR TITLE
use object ref instead of array ref

### DIFF
--- a/library/ChatGPT.php
+++ b/library/ChatGPT.php
@@ -360,7 +360,7 @@ class ChatGPT {
         if( isset( $message->tool_calls ) ) {
             $function_calls = array_filter(
                 $message->tool_calls,
-                fn( $tool_call ) => $tool_call["type"] === "function"
+                fn( $tool_call ) => $tool_call->type === "function"
             );
 
             if( $raw_function_response ) {


### PR DESCRIPTION
```
PHP Fatal error:  Uncaught Error: Cannot use object of type stdClass as array in /php-gpt-funcs-master/library/ChatGPT.php:363
Stack trace:
#0 [internal function]: ChatGPT->{closure}()
#1 /php-gpt-funcs-master/library/ChatGPT.php(364): array_filter()
#2 /php-gpt-funcs-master/library/ChatGPT.php(291): ChatGPT->handle_functions()
```